### PR TITLE
Add basic .NET backend and AI builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# .NET build artifacts
+backend/bin/
+backend/obj/

--- a/README.md
+++ b/README.md
@@ -1,64 +1,23 @@
-<<<<<<< HEAD
-# datafortune
-a simple web application  to allow user to register and login
-=======
-# CmwRegistration
+# Datafortune Demo App
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.2.0.
+This repository contains an Angular frontend with a simple .NET 8 Web API backend. The application now includes an experimental **AI Builder** feature that allows you to generate basic UI forms without writing code.
 
-## Development server
+## Prerequisites
+- Node.js and npm
+- .NET SDK 8
 
-To start a local development server, run:
-
+## Running the Angular Frontend
 ```bash
-ng serve
+npm install
+npm start
 ```
+Navigate to `http://localhost:4200` to access the app.
 
-Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
-
-## Code scaffolding
-
-Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
-
+## Running the .NET Backend
 ```bash
-ng generate component component-name
+dotnet run --project backend
 ```
+The API will listen on `http://localhost:5000` by default.
 
-For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
-
-```bash
-ng generate --help
-```
-
-## Building
-
-To build the project run:
-
-```bash
-ng build
-```
-
-This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
-
-## Running unit tests
-
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
-
-```bash
-ng test
-```
-
-## Running end-to-end tests
-
-For end-to-end (e2e) testing, run:
-
-```bash
-ng e2e
-```
-
-Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
-
-## Additional Resources
-
-For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
->>>>>>> 057fd8a (initial commit)
+## AI Builder
+Open `http://localhost:4200/builder` to create dynamic screens. Provide a screen name and comma separated list of fields. Saved definitions are stored in a SQLite database (`screens.db`).

--- a/backend/Controllers/ScreenController.cs
+++ b/backend/Controllers/ScreenController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using backend.Models;
+
+namespace backend.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ScreenController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public ScreenController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<IEnumerable<ScreenDefinition>> GetScreens()
+        {
+            return await _context.Screens.ToListAsync();
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<ScreenDefinition>> CreateScreen([FromBody] ScreenDefinition screen)
+        {
+            _context.Screens.Add(screen);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetScreens), new { id = screen.Id }, screen);
+        }
+    }
+}

--- a/backend/Models/AppDbContext.cs
+++ b/backend/Models/AppDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace backend.Models
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<ScreenDefinition> Screens => Set<ScreenDefinition>();
+    }
+}

--- a/backend/Models/ScreenDefinition.cs
+++ b/backend/Models/ScreenDefinition.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace backend.Models
+{
+    public class ScreenDefinition
+    {
+        [Key]
+        public int Id { get; set; }
+        [Required]
+        public string Name { get; set; } = string.Empty;
+        public string DefinitionJson { get; set; } = string.Empty;
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,24 @@
+using backend.Models;
+using Microsoft.EntityFrameworkCore;
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=screens.db"));
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+
+app.UseAuthorization();
+app.MapControllers();
+app.Run();

--- a/backend/Properties/launchSettings.json
+++ b/backend/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:40116",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5275",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=screens.db"
+  }
+}

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/backend/backend.http
+++ b/backend/backend.http
@@ -1,0 +1,6 @@
+@backend_HostAddress = http://localhost:5275
+
+GET {{backend_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,11 +3,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './components/login/login.component';
 import { RegistrationComponent } from './components/registration/registration.component';
 import { ConfirmationComponent } from './components/confirmation/confirmation.component';
+import { AiBuilderComponent } from "./components/ai-builder/ai-builder.component";
 import { AuthGuard } from './guards/auth.guard';
 
 const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   { path: 'login', component: LoginComponent },
+  { path: 'builder', component: AiBuilderComponent },
   { path: 'register', component: RegistrationComponent, canActivate: [AuthGuard] },
   { path: 'confirmation', component: ConfirmationComponent, canActivate: [AuthGuard] },
   { path: '**', redirectTo: '/login' }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,8 @@ import { LoginComponent } from './components/login/login.component';
 import { ConfirmationComponent } from './components/confirmation/confirmation.component';
 import { AuthGuard } from './guards/auth.guard';
 import { DialogComponent } from './shared/dialog/dialog.component';
+import { AiBuilderComponent } from './components/ai-builder/ai-builder.component';
+import { JsonParsePipe } from './pipes/json-parse.pipe';
 
 @NgModule({
   declarations: [
@@ -17,7 +19,9 @@ import { DialogComponent } from './shared/dialog/dialog.component';
     RegistrationComponent,
     LoginComponent,
     ConfirmationComponent,
-    DialogComponent
+    DialogComponent,
+    AiBuilderComponent,
+    JsonParsePipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/ai-builder/ai-builder.component.html
+++ b/src/app/components/ai-builder/ai-builder.component.html
@@ -1,0 +1,26 @@
+<div class="builder">
+  <h2>Create Screen</h2>
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <label>
+      Name:
+      <input formControlName="name" />
+    </label>
+    <label>
+      Fields (comma separated):
+      <input formControlName="fields" />
+    </label>
+    <button type="submit">Save</button>
+  </form>
+
+  <div class="screens" *ngIf="screens.length">
+    <h3>Generated Screens</h3>
+    <div *ngFor="let screen of screens" class="screen">
+      <h4>{{ screen.name }}</h4>
+      <form>
+        <div *ngFor="let f of (screen.definitionJson | jsonParse).fields">
+          <label>{{f}}<input /></label>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/app/components/ai-builder/ai-builder.component.scss
+++ b/src/app/components/ai-builder/ai-builder.component.scss
@@ -1,0 +1,12 @@
+.builder {
+  max-width: 500px;
+  margin: 0 auto;
+}
+.screens {
+  margin-top: 20px;
+}
+.screen {
+  padding: 10px;
+  border: 1px solid #ccc;
+  margin-bottom: 10px;
+}

--- a/src/app/components/ai-builder/ai-builder.component.spec.ts
+++ b/src/app/components/ai-builder/ai-builder.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AiBuilderComponent } from './ai-builder.component';
+
+describe('AiBuilderComponent', () => {
+  let component: AiBuilderComponent;
+  let fixture: ComponentFixture<AiBuilderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AiBuilderComponent],
+      imports: [ReactiveFormsModule, HttpClientTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AiBuilderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/ai-builder/ai-builder.component.ts
+++ b/src/app/components/ai-builder/ai-builder.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { ScreenService, ScreenDefinition } from '../../services/screen.service';
+
+@Component({
+  selector: 'app-ai-builder',
+  templateUrl: './ai-builder.component.html',
+  styleUrls: ['./ai-builder.component.scss']
+})
+export class AiBuilderComponent implements OnInit {
+  form!: FormGroup;
+  screens: ScreenDefinition[] = [];
+
+  constructor(private fb: FormBuilder, private screenService: ScreenService) {}
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      name: [''],
+      fields: ['']
+    });
+    this.loadScreens();
+  }
+
+  loadScreens(): void {
+    this.screenService.getScreens().subscribe(s => (this.screens = s));
+  }
+
+  submit(): void {
+    const fields = (this.form.value.fields as string).split(',').map(f => f.trim());
+    const definition = JSON.stringify({ fields });
+    const screen: ScreenDefinition = { name: this.form.value.name, definitionJson: definition };
+    this.screenService.createScreen(screen).subscribe(() => {
+      this.form.reset();
+      this.loadScreens();
+    });
+  }
+}

--- a/src/app/components/login/login.component.spec.ts
+++ b/src/app/components/login/login.component.spec.ts
@@ -2,21 +2,24 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoginComponent } from './login.component';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { DialogService } from '../../shared/dialog.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
   let mockRouter = { navigate: jasmine.createSpy('navigate') };
+  let dialogService: DialogService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [LoginComponent],
       imports: [FormsModule],
-      providers: [{ provide: Router, useValue: mockRouter }]
+      providers: [{ provide: Router, useValue: mockRouter }, DialogService]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
+    dialogService = TestBed.inject(DialogService);
     fixture.detectChanges();
   });
 
@@ -27,13 +30,14 @@ describe('LoginComponent', () => {
   it('should log in with correct password', () => {
     component.password = 'Speak2025';
     component.onLogin();
-    expect(localStorage.getItem('loggedIn')).toBe('true');
+    expect(sessionStorage.getItem('authenticated')).toBe('true');
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/register']);
   });
 
   it('should show error with wrong password', () => {
     component.password = 'Wrong';
+    spyOn(dialogService, 'showDialog');
     component.onLogin();
-    expect(component.passwordError).toBeTrue();
+    expect(dialogService.showDialog).toHaveBeenCalled();
   });
 });

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -15,8 +15,8 @@ export class LoginComponent {
 
   constructor(private router: Router, private dialogService: DialogService) {}
 
-  onLogin(form: NgForm) {
-    if (form.invalid) {
+  onLogin(form?: NgForm) {
+    if (form && form.invalid) {
       this.dialogService.showDialog('Validation Error', 'Password is required.');
       return;
     }

--- a/src/app/pipes/json-parse.pipe.ts
+++ b/src/app/pipes/json-parse.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'jsonParse' })
+export class JsonParsePipe implements PipeTransform {
+  transform(value: string | null): any {
+    if (!value) return null;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/app/services/screen.service.ts
+++ b/src/app/services/screen.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface ScreenDefinition {
+  id?: number;
+  name: string;
+  definitionJson: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ScreenService {
+  private apiUrl = '/api/Screen';
+
+  constructor(private http: HttpClient) {}
+
+  getScreens(): Observable<ScreenDefinition[]> {
+    return this.http.get<ScreenDefinition[]>(this.apiUrl);
+  }
+
+  createScreen(screen: ScreenDefinition): Observable<ScreenDefinition> {
+    return this.http.post<ScreenDefinition>(this.apiUrl, screen);
+  }
+}


### PR DESCRIPTION
## Summary
- implement minimal .NET Web API with SQLite
- add Angular AI Builder to generate simple forms
- update login component and tests
- document running frontend and backend

## Testing
- `dotnet build backend`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685638648e54832f9cc948c972e87c2c